### PR TITLE
fix: add onrender.com to CSP connect-src

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="VoxRip">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://cdn.tailwindcss.com https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tcgplayer.com https://images.ygoprodeck.com https://*.supabase.co blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://db.ygoprodeck.com https://esm.sh http://localhost:* http://127.0.0.1:*;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://cdn.tailwindcss.com https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.tcgplayer.com https://images.ygoprodeck.com https://*.supabase.co blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://db.ygoprodeck.com https://esm.sh https://*.onrender.com http://localhost:* http://127.0.0.1:*;">
 
     <title>VoxRip - Yu-Gi-Oh Card Manager</title>
 


### PR DESCRIPTION
The Content-Security-Policy added in PR #31 was missing the backend API origin (ygopyguy.onrender.com) from connect-src, causing all fetch requests to the backend to be silently blocked by the browser.